### PR TITLE
Updated chokidar version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -163,7 +163,7 @@ babel-cli@^6.23.0:
     source-map "^0.5.0"
     v8flags "^2.0.10"
   optionalDependencies:
-    chokidar "^1.6.1"
+    chokidar "^3.4.2"
 
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
New version will work with Node.js v14+ and it needs less dependencies