### PR TITLE
Fix fpb-lint check lists alphabetical order of non alphabetical language pages #4

### DIFF
--- a/dist/lint.js
+++ b/dist/lint.js
@@ -37,11 +37,10 @@ var commonPreset = {
   filenames.forEach(function (filename) {
     var doc = fs.readFileSync(filename);
     var lang = getLangFromFilename(filename);
-    var preset = commonPreset;
+    var processor = remark().use(commonPreset);
     if (langsToAlphabetize.includes(lang)) {
-      preset.plugins.push([require('remark-lint-alphabetize-lists'), lang]);
+      processor.use(require('remark-lint-alphabetize-lists'), lang);
     }
-    var processor = remark().use(preset);
 
     processor.process(doc, function (err, file) {
       if (report(err || file) !== 'no issues found') {

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -75,11 +75,10 @@ const commonPreset = {
   filenames.forEach((filename) => {
     const doc = fs.readFileSync(filename);
     const lang = getLangFromFilename(filename);
-    const preset = commonPreset;
+    const processor = remark().use(commonPreset);
     if (langsToAlphabetize.includes(lang)) {
-      preset.plugins.push([require('remark-lint-alphabetize-lists'), lang]);
+      processor.use(require('remark-lint-alphabetize-lists'), lang);
     }
-    const processor = remark().use(preset);
 
     processor.process(doc, (err, file) => {
       if (report(err || file) !== 'no issues found') {


### PR DESCRIPTION
This fixes #4