### PR TITLE
Update language code bl to bn

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -19,7 +19,7 @@ const langsToAlphabetize = [
   'ar',
   'az',
   'bg',
-  'bl',
+  'bn',
   'cs',
   'de',
   'dk',


### PR DESCRIPTION
bl does not stand for Bangla,  it should be bn (iso standard). we are working contribution bn (Bangla) all the place.